### PR TITLE
Add buffer release method when data transition is stopped

### DIFF
--- a/include/mossfw/mossfw_component.h
+++ b/include/mossfw/mossfw_component.h
@@ -129,6 +129,7 @@ int mossfw_get_delivereddata_single(mossfw_input_t *in,
                                     mossfw_onedata_t *rdat);
 bool mossfw_deliverback_dataarray(mossfw_input_t *in, mossfw_data_t *dat,
                                int used);
+mossfw_data_t *mossfw_release_delivereddata_array(mossfw_input_t *in);
 
 int mossfw_set_waitcondition(mossfw_input_t *in, int wait_size,
                           mossfw_callback_op_t *op);

--- a/include/mossfw/mossfw_ringbuffary.h
+++ b/include/mossfw/mossfw_ringbuffary.h
@@ -68,6 +68,7 @@ bool mossfw_ringbuffarray_isfull(mossfw_ringbuffarray_t *ary);
 int mossfw_ringbuffarray_storednum(mossfw_ringbuffarray_t *ary);
 int mossfw_ringbuffarray_storedbytes(mossfw_ringbuffarray_t *ary);
 
+mossfw_data_t *mossfw_ringbuffarray_releasedata(mossfw_ringbuffarray_t *ary);
 mossfw_data_t *mossfw_ringbuffarray_getdata(mossfw_ringbuffarray_t *ary,
                                             int *used, bool nonblock);
 bool mossfw_ringbuffarray_setdata(mossfw_ringbuffarray_t *ary,

--- a/src/mossfw/mossfw_component.c
+++ b/src/mossfw/mossfw_component.c
@@ -827,6 +827,25 @@ bool mossfw_deliverback_dataarray(mossfw_input_t *in, mossfw_data_t *dat,
 }
 
 /****************************************************************************
+ * name: mossfw_release_delivereddata_array
+ ****************************************************************************/
+
+mossfw_data_t *mossfw_release_delivereddata_array(mossfw_input_t *in)
+{
+  mossfw_data_t *ret = NULL;
+
+  if (in)
+    {
+      if (MOSSFW_DATA_TYPE_ISARRAY(in->type))
+        {
+          ret = mossfw_ringbuffarray_releasedata(in->ringbuff.array);
+        }
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * name: mossfw_get_delivereddata_array
  ****************************************************************************/
 


### PR DESCRIPTION
Data is remain in internal queue after stopping data transition.
This PR adds a method to release data in the queue safely.
